### PR TITLE
Fix crash when image is nil

### DIFF
--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -102,7 +102,7 @@ open class Node: SKShapeNode {
      
      - Returns: A new node.
      */
-    public convenience init(text: String?, image: UIImage?, color: UIColor, radius: CGFloat) {
+    public convenience init(text: String?, image: UIImage? = nil, color: UIColor, radius: CGFloat) {
         self.init()
         self.init(circleOfRadius: radius)
         

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -60,8 +60,11 @@ open class Node: SKShapeNode {
      */
     open var image: UIImage? {
         didSet {
-            guard let image = image else { return }
-            texture = SKTexture(image: image)
+            if let image = image {
+                texture = SKTexture(image: image)
+            } else {
+                texture = nil
+            }
         }
     }
     

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -75,7 +75,7 @@ open class Node: SKShapeNode {
         set { sprite.color = newValue }
     }
     
-    private(set) var texture: SKTexture!
+    private(set) var texture: SKTexture? = nil
     
     /**
      The selection state of the node.
@@ -137,7 +137,9 @@ open class Node: SKShapeNode {
      */
     open func selectedAnimation() {
         run(.scale(to: 4/3, duration: 0.2))
-        sprite.run(.setTexture(texture))
+        if let texture = texture {
+          sprite.run(.setTexture(texture))
+        }
     }
     
     /**


### PR DESCRIPTION
`image` property is optional, but `texture` property is not optional. 
So when I `init` with `image` `nil`, app crashes in `selectedAnimation` func.

And also `configure` func is open func. I can set `image` to `nil` after `init`.
But `texture` is not changed because of `guard` statement.