### PR TITLE
Re-config physics of Magnetic when size is changed

### DIFF
--- a/Sources/Magnetic.swift
+++ b/Sources/Magnetic.swift
@@ -61,18 +61,30 @@ open class Magnetic: SKScene {
     }
     
     func commonInit() {
-        self.backgroundColor = .white
-        self.scaleMode = .aspectFill
-        self.physicsWorld.gravity = CGVector(dx: 0, dy: 0)
-        self.physicsBody = SKPhysicsBody(edgeLoopFrom: { () -> CGRect in
+        backgroundColor = .white
+        scaleMode = .aspectFill
+        configPhysics()
+    }
+  
+  
+    private func configPhysics() {
+        physicsWorld.gravity = CGVector(dx: 0, dy: 0)
+        physicsBody = SKPhysicsBody(edgeLoopFrom: { () -> CGRect in
             var frame = self.frame
             frame.size.width = CGFloat(magneticField.minimumRadius)
             frame.origin.x -= frame.size.width / 2
             return frame
         }())
+        
         magneticField.position = CGPoint(x: size.width / 2, y: size.height / 2)
     }
-    
+  
+    override open var size: CGSize {
+        didSet {
+            configPhysics()
+        }
+    }
+
     override open func addChild(_ node: SKNode) {
         var x = -node.frame.width // left
         if children.count % 2 == 0 {

--- a/Sources/MagneticView.swift
+++ b/Sources/MagneticView.swift
@@ -31,5 +31,9 @@ public class MagneticView: SKView {
     func commonInit() {
         _ = magnetic
     }
-    
+  
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        magnetic.size = bounds.size
+    }
 }


### PR DESCRIPTION
I am using `MagneticView` with Autolayout.
Its frame is zero when I initialize and `Magnetic` size is also zero cause it is initialized with view size.

After `viewDidLoad`, `MagneticView` frame is changed but not `Magnetic` size.
So I override `func layoutSubview` in `MagneticView`.
And add `size` property `didSet` observers for reconfig its physics.