### PR TITLE
Fix readme example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,21 +39,14 @@ import Magnetic
 
 class ViewController: UIViewController {
 
-    var skView: SKView {
-        return view as! SKView
-    }
-
-    override func loadView() {
-        super.loadView()
-
-        self.view = SKView(frame: self.view.bounds)
-    }
+    var magnetic: Magnetic?
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let magnetic = Magnetic(size: self.view.bounds.size)
-        skView.presentScene(magnetic)
+        let magneticView = MagneticView.init(frame: self.view.bounds)
+        magnetic = magneticView.magnetic
+        self.view.addSubview(magneticView)
     }
 
 }


### PR DESCRIPTION
Since the [`init(size:)`](https://github.com/efremidze/Magnetic/blob/master/Sources/Magnetic.swift#L57) method of the `Magnetic` class has the`internal` access control, we can't use this initializer when using `Magnetic` as an external dependency (i.e.: Cocoapods)

I've decided to keep a reference of `magnetic` property of `MagneticView` to keep the [Nodes section](https://github.com/efremidze/Magnetic#nodes) readable.