### PR TITLE
Fixed Xcode 9.1 warning

### DIFF
--- a/Sources/SKMultilineLabelNode.swift
+++ b/Sources/SKMultilineLabelNode.swift
@@ -32,7 +32,7 @@ open class SKMultilineLabelNode: SKNode {
         
         var stack = Stack<String>()
         var sizingLabel = makeSizingLabel()
-        let words = separator.map { text.components(separatedBy: $0) } ?? text.characters.map { String($0) }
+        let words = separator.map { text.components(separatedBy: $0) } ?? text.map { String($0) }
         for word in words {
             sizingLabel.text += word
             if sizingLabel.frame.width > width {


### PR DESCRIPTION
Hi, 

Fixed a simple warning in Xcode 9.1, thanks for this project.

<!-- Thanks for contributing to _Magnetic_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
Why is this change required? What problem does it solve?
* Fixes a warning for Xcode 9.1 / iOS 11.1
<!--- If it fixes an open issue, please link to the issue here. -->
Please describe how you tested your changes.
* Ran and tried the example project in Xcode 9.1 and Xcode 9.0.1
<!-- If you are submitting a link to your app for the README, you can omit this section. -->

### Description
<!--- Describe your changes in detail. -->
The warning said: 
`characters' is deprecated: Please use String or Substring directly`
So I changed text.characters.map to text.map (see changes).