### PR TITLE
fix flatMap deprecation warning in Swift 4.1 (replaced with compactMap)

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -48,7 +48,7 @@ class ViewController: UIViewController {
     @IBAction func reset(_ sender: UIControl?) {
         let speed = magnetic.physicsWorld.speed
         magnetic.physicsWorld.speed = 0
-        let sortedNodes = magnetic.children.flatMap { $0 as? Node }.sorted { node, nextNode in
+        let sortedNodes = magnetic.children.compactMap { $0 as? Node }.sorted { node, nextNode in
             let distance = node.position.distance(from: magnetic.magneticField.position)
             let nextDistance = nextNode.position.distance(from: magnetic.magneticField.position)
             return distance < nextDistance && node.isSelected

--- a/Sources/Magnetic.swift
+++ b/Sources/Magnetic.swift
@@ -35,7 +35,7 @@ open class Magnetic: SKScene {
      The selected children.
      */
     open var selectedChildren: [Node] {
-        return children.flatMap { $0 as? Node }.filter { $0.isSelected }
+        return children.compactMap { $0 as? Node }.filter { $0.isSelected }
     }
     
     /**
@@ -126,7 +126,7 @@ extension Magnetic {
         if
             !isDragging,
             let point = touches.first?.location(in: self),
-            let node = nodes(at: point).flatMap({ $0 as? Node }).filter({ $0.path!.contains(convert(point, to: $0)) }).first
+            let node = nodes(at: point).compactMap({ $0 as? Node }).filter({ $0.path!.contains(convert(point, to: $0)) }).first
         {
             if node.isSelected {
                 node.isSelected = false


### PR DESCRIPTION
<!-- Thanks for contributing to _Magnetic_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->

This commit fixes the deprecation of flatMap in Swift 4.1 (Xcode 9.3).
I have not tested this in Xcode 9.2 yet, as it's not installed on my machine. 

I've tested the changes with the example in Xcode 9.3 on iOS 11.3 beta 3

Feel free to reject if it's too early (because beta)

### Description
<!--- Describe your changes in detail. -->
* changed the word "flatMap" to the new "compactMap".