### PR TITLE
Accessibility/VoiceOver usability improvements

### DIFF
--- a/Sources/Magnetic.swift
+++ b/Sources/Magnetic.swift
@@ -78,6 +78,7 @@ import SpriteKit
     }
     
     func commonInit() {
+        if #available(iOS 11.0, *) { accessibilityContainerType = .list }
         backgroundColor = .white
         scaleMode = .aspectFill
         configure()

--- a/Sources/MagneticView.swift
+++ b/Sources/MagneticView.swift
@@ -31,12 +31,71 @@ public class MagneticView: SKView {
     
     func commonInit() {
         _ = magnetic
+        accessibilityCreateSelectionRotor(withName: "Selected",
+                                          usingScene: magnetic)
     }
-    
+
     public override func layoutSubviews() {
         super.layoutSubviews()
         
         magnetic.size = bounds.size
     }
     
+}
+
+// Accessibility extension
+private extension MagneticView {
+    private func accessibilityCreateSelectionRotor(withName name: String,
+                                                   usingScene magnet: Magnetic) {
+
+		// iOS 10+ allows a VoiceOver user to skip to selected elements
+		guard #available(iOS 10.0, *) else { return }
+
+        let selectedRotor = UIAccessibilityCustomRotor(name: name) { predicate in
+            // Sort by Node name/text and ensure there is at least 1 selected Node
+            let selected = magnet
+                .selectedChildren
+                .sorted { $0.text ?? ""  < $1.text ?? "" }
+            let all = magnet.children.compactMap { $0 as? Node }
+            guard selected.count > 0 else { return nil }
+            
+            // See which direction the user is scrolling
+            let isDirectionForward = predicate.searchDirection == .next
+            
+            // Get the index of current focused Node
+            var currentNodeIndex = isDirectionForward ? all.count : -1
+            if
+                let current = predicate.currentItem.targetElement,
+                let currentNode = current as? Node {
+                currentNodeIndex = all.firstIndex(of: currentNode) ?? currentNodeIndex
+            }
+            
+            if let node = self.fetchNextSelectedNode(inDirection: isDirectionForward,
+                                                     fromCurrentNodeIndex: currentNodeIndex,
+                                                     inNodeArray: all) {
+                return UIAccessibilityCustomRotorItemResult(targetElement: node,
+                                                            targetRange: nil)
+            } else { return nil }
+        }
+
+        accessibilityCustomRotors = [selectedRotor]
+    }
+
+    private func fetchNextSelectedNode(inDirection forwards: Bool,
+                                       fromCurrentNodeIndex index: Int,
+                                       inNodeArray all: [Node]) -> Node? {
+        // A closure used to update the while loop
+        let nextSearchNode = { (nodeIndex) in forwards ? nodeIndex - 1 : nodeIndex + 1 }
+        
+        var searchNode = nextSearchNode(index)
+        while searchNode >= 0 && searchNode < all.count {
+            defer { searchNode = nextSearchNode(searchNode) }
+            if all[searchNode].isSelected {
+                return all[searchNode]
+            }
+        }
+        
+        return nil
+    }
+
 }

--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -65,9 +65,30 @@ import SpriteKit
             guard isSelected != oldValue else { return }
             if isSelected {
                 selectedAnimation()
+                accessibilityTraits = .selected
             } else {
                 deselectedAnimation()
+                accessibilityTraits = .none
             }
+        }
+    }
+
+    /**
+     The internal accessibilityPath used by the node.
+     */
+    private var overridenAccessibilityPath: UIBezierPath?
+
+    open override var accessibilityPath: UIBezierPath? {
+        get {
+            if let path = self.overridenAccessibilityPath {
+                return path
+            }
+
+            return UIBezierPath(ovalIn: self.accessibilityFrame)
+        }
+
+        set {
+            self.overridenAccessibilityPath = newValue
         }
     }
     
@@ -194,6 +215,10 @@ import SpriteKit
     public init(text: String? = nil, image: UIImage? = nil, color: UIColor, path: CGPath, marginScale: CGFloat = 1.01) {
         super.init()
         self.path = path
+
+        self.isAccessibilityElement = true
+        self.shouldGroupAccessibilityChildren = true
+
         regeneratePhysicsBody(withPath: path)
         self.color = color
         self.strokeColor = .white
@@ -223,6 +248,7 @@ import SpriteKit
     }
     
     open func configure(text: String?, image: UIImage?, color: UIColor) {
+        self.accessibilityLabel = text
         self.text = text
         self.image = image
         self.color = color


### PR DESCRIPTION
<!-- Thanks for contributing to _Magnetic_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->
Thanks for the delightful library! In preparing for a user test, I noticed a few minor usability issues with VoiceOver(VO):
- MultiLineLabels are read as individual label elements as opposed to a single label
- Selection state of a node isn't presented to a VO user
- There is no easy way for a VO user to quickly confirm selections, which is a benefit of this library for a non-VO user

### Description
<!--- Describe your changes in detail. -->
To address the above 3 issues, I have made the following changes
- Made **Node.swift** class set ```accessibilityElement``` to true (overriding it's children's accessibility settings), as well as enabled the property to group it's children. This allows multiline labels to be read as one, if the nodes accessibilityLabel is not set, but that's set as well. Additionally, this PR adds an ```accessibilityPath``` that is, by default computed to be an ellipse inside the sprite shape, but can be overridden or removed if subclassed. 
- Added ```accessibilityTraits``` to be selected when a Node is tapped, i.e in the isSelected property.
- For iOS 10.0 and above, **MagneticView.swift** is initialized with a "Selected" custom rotor, using ```accessibilityCustomRotors```. 
- Note that for iOS 11.0, the entire **Magnetic.swift** scene has the added property ```accessibilityContainerType``` to be .list. This lets a VO user know when they are entering and leaving the list of items

I wasn't entirely sure if OS specific code is allowed in this library, but given that this makes tangible benefits to a VO user, I'm hoping it's alright. Tested on Xcode 9.4 and iOS 11.4 betas.

Happy to make changes as needed!