### PR TITLE
Remove MaskNode and use SKShapeNode as root of Node

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -98,7 +98,7 @@ extension ViewController: MagneticDelegate {
 class ImageNode: Node {
     override var image: UIImage? {
         didSet {
-            sprite.texture = image.map { SKTexture(image: $0) }
+            texture = image.map { SKTexture(image: $0) }
         }
     }
     override func selectedAnimation() {}


### PR DESCRIPTION
### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
Probably Fix issue #79

### Description
SKCropNode can cause offscreen memory buffer and slow down the performance. So I remove the MaskNode in this project and just use the SKShapeNode.
