### PR TITLE
fix cannot find 'UIAccessibilityCustomRotor'

### DIFF
--- a/Sources/MagneticView+Accessibility.swift
+++ b/Sources/MagneticView+Accessibility.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 efremidze. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 extension MagneticView {
     func accessibilityCreateSelectionRotor(withName name: String, usingScene magnet: Magnetic) {


### PR DESCRIPTION
<!-- Thanks for contributing to _Magnetic_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] -->

### Checklist
- [ ] I've tested my changes.
- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [ ] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
<!-- If you are submitting a link to your app for the README, you can omit this section. -->

### Description
<!--- Describe your changes in detail. -->
In Xcode Version 15.3, there will be a "cannot find 'UIAccessibilityCustomRotor'" error when adding from SPM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved accessibility support in the MagneticView component by updating import statements for better framework integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->