### PR TITLE
Bump Package.swift min version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Magnetic",
     platforms: [
-        .iOS(.v9)
+        .iOS(.v13)
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.


### PR DESCRIPTION
Updated SPM minimum version to iOS 13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the minimum iOS platform version requirement for the "Magnetic" package from iOS 9 to iOS 13, enabling access to newer features and improvements.
  
- **Impact**
	- This change may affect compatibility with older devices and iOS versions, as applications relying on iOS 9 will no longer support this package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->